### PR TITLE
Codex/enhancements UI three subtasks

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -22,9 +22,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.16</string>
+	<string>0.4.17</string>
 	<key>CFBundleVersion</key>
-	<string>50</string>
+	<string>51</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MeetingAssistantAI/Resources/Info.plist
+++ b/MeetingAssistantAI/Resources/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.16</string>
+	<string>0.4.17</string>
 	<key>CFBundleVersion</key>
-	<string>50</string>
+	<string>51</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>MachServices</key>

--- a/Packages/MeetingAssistantCore/Sources/Common/AppVersion.swift
+++ b/Packages/MeetingAssistantCore/Sources/Common/AppVersion.swift
@@ -15,10 +15,10 @@ public enum AppVersion {
     // MARK: - Hardcoded Constants (Update these when releasing)
 
     /// Hardcoded version string - update this when releasing a new version
-    private static let hardcodedVersion = "0.4.16"
+    private static let hardcodedVersion = "0.4.17"
 
     /// Hardcoded build number - update this when creating a new build
-    private static let hardcodedBuild = "50"
+    private static let hardcodedBuild = "51"
 
     // MARK: - Public API
 

--- a/Packages/MeetingAssistantCore/Sources/Common/Resources/en.lproj/Localizable.strings
+++ b/Packages/MeetingAssistantCore/Sources/Common/Resources/en.lproj/Localizable.strings
@@ -287,6 +287,8 @@
 "settings.enhancements.providers.editor.title_edit" = "Edit provider";
 "settings.enhancements.providers.editor.provider_label" = "Provider";
 "settings.enhancements.providers.editor.name" = "Name";
+"settings.enhancements.providers.editor.icon" = "Icon";
+"settings.enhancements.providers.editor.icon_help" = "Choose how this custom provider appears in the list.";
 "settings.enhancements.providers.editor.remove_api_and_edit" = "Remove API key and edit";
 "settings.enhancements.providers.editor.create_failed" = "Could not create provider registration.";
 "settings.enhancements.providers.editor.missing_registration" = "Provider registration no longer exists.";

--- a/Packages/MeetingAssistantCore/Sources/Common/Resources/pt.lproj/Localizable.strings
+++ b/Packages/MeetingAssistantCore/Sources/Common/Resources/pt.lproj/Localizable.strings
@@ -287,7 +287,7 @@
 "settings.enhancements.providers.editor.title_edit" = "Editar provedor";
 "settings.enhancements.providers.editor.provider_label" = "Provedor";
 "settings.enhancements.providers.editor.name" = "Nome";
-"settings.enhancements.providers.editor.icon" = "Icone";
+"settings.enhancements.providers.editor.icon" = "Ícone";
 "settings.enhancements.providers.editor.icon_help" = "Escolha como este provedor customizado aparece na lista.";
 "settings.enhancements.providers.editor.remove_api_and_edit" = "Remover API e editar";
 "settings.enhancements.providers.editor.create_failed" = "Não foi possível criar o registro do provedor.";

--- a/Packages/MeetingAssistantCore/Sources/Common/Resources/pt.lproj/Localizable.strings
+++ b/Packages/MeetingAssistantCore/Sources/Common/Resources/pt.lproj/Localizable.strings
@@ -287,6 +287,8 @@
 "settings.enhancements.providers.editor.title_edit" = "Editar provedor";
 "settings.enhancements.providers.editor.provider_label" = "Provedor";
 "settings.enhancements.providers.editor.name" = "Nome";
+"settings.enhancements.providers.editor.icon" = "Icone";
+"settings.enhancements.providers.editor.icon_help" = "Escolha como este provedor customizado aparece na lista.";
 "settings.enhancements.providers.editor.remove_api_and_edit" = "Remover API e editar";
 "settings.enhancements.providers.editor.create_failed" = "Não foi possível criar o registro do provedor.";
 "settings.enhancements.providers.editor.missing_registration" = "O registro do provedor não existe mais.";

--- a/Packages/MeetingAssistantCore/Sources/Infrastructure/Models/AppSettingsAudioAndAIConfiguration.swift
+++ b/Packages/MeetingAssistantCore/Sources/Infrastructure/Models/AppSettingsAudioAndAIConfiguration.swift
@@ -234,6 +234,7 @@ public struct EnhancementsProviderRegistration: Codable, Identifiable, Equatable
     public var provider: AIProvider
     public var displayName: String
     public var baseURLOverride: String?
+    public var iconSystemName: String?
     public var createdAt: Date
     public var updatedAt: Date
 
@@ -242,6 +243,7 @@ public struct EnhancementsProviderRegistration: Codable, Identifiable, Equatable
         provider: AIProvider,
         displayName: String,
         baseURLOverride: String? = nil,
+        iconSystemName: String? = nil,
         createdAt: Date = Date(),
         updatedAt: Date = Date()
     ) {
@@ -249,6 +251,7 @@ public struct EnhancementsProviderRegistration: Codable, Identifiable, Equatable
         self.provider = provider
         self.displayName = displayName
         self.baseURLOverride = baseURLOverride?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.iconSystemName = iconSystemName?.trimmingCharacters(in: .whitespacesAndNewlines)
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         normalizeInPlace()
@@ -281,8 +284,12 @@ public struct EnhancementsProviderRegistration: Codable, Identifiable, Equatable
         if provider == .custom {
             let trimmedBaseURL = baseURLOverride?.trimmingCharacters(in: .whitespacesAndNewlines)
             baseURLOverride = trimmedBaseURL?.isEmpty == true ? nil : trimmedBaseURL
+
+            let trimmedIconSystemName = iconSystemName?.trimmingCharacters(in: .whitespacesAndNewlines)
+            iconSystemName = trimmedIconSystemName?.isEmpty == true ? nil : trimmedIconSystemName
         } else {
             baseURLOverride = nil
+            iconSystemName = nil
         }
     }
 }

--- a/Packages/MeetingAssistantCore/Sources/Infrastructure/Models/AppSettingsStore/AIModeSelection.swift
+++ b/Packages/MeetingAssistantCore/Sources/Infrastructure/Models/AppSettingsStore/AIModeSelection.swift
@@ -51,14 +51,16 @@ public extension AppSettingsStore {
     func addEnhancementsProviderRegistration(
         provider: AIProvider,
         displayName: String? = nil,
-        baseURLOverride: String? = nil
+        baseURLOverride: String? = nil,
+        iconSystemName: String? = nil
     ) -> EnhancementsProviderRegistration? {
         guard canAddEnhancementsProviderRegistration(provider) else { return nil }
 
         let registration = EnhancementsProviderRegistration(
             provider: provider,
             displayName: displayName ?? defaultRegistrationDisplayName(for: provider),
-            baseURLOverride: provider == .custom ? baseURLOverride : nil
+            baseURLOverride: provider == .custom ? baseURLOverride : nil,
+            iconSystemName: provider == .custom ? iconSystemName : nil
         )
 
         var updated = enhancementsProviderRegistrations

--- a/Packages/MeetingAssistantCore/Sources/UI/components/settings/EnhancementsModelSelectionSheet.swift
+++ b/Packages/MeetingAssistantCore/Sources/UI/components/settings/EnhancementsModelSelectionSheet.swift
@@ -3,6 +3,22 @@ import MeetingAssistantCoreInfrastructure
 import SwiftUI
 
 public struct EnhancementsModelSelectionSheet: View {
+    private struct ProviderGroup: Identifiable {
+        struct Key: Hashable {
+            let provider: AIProvider
+            let registrationID: UUID?
+            let title: String
+        }
+
+        let key: Key
+        var options: [EnhancementsProviderModelOption]
+
+        var id: String {
+            let registrationPart = key.registrationID?.uuidString ?? key.provider.rawValue
+            return "\(registrationPart)::\(key.title)"
+        }
+    }
+
     let options: [EnhancementsProviderModelOption]
     let isSelected: (EnhancementsProviderModelOption) -> Bool
     let onSelect: (EnhancementsProviderModelOption) -> Void
@@ -38,27 +54,17 @@ public struct EnhancementsModelSelectionSheet: View {
                 .padding(.top, 12)
                 .padding(.bottom, 8)
 
-                List(filteredOptions, id: \.id) { option in
-                    Button {
-                        onSelect(option)
-                    } label: {
-                        HStack(spacing: 8) {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(option.modelID)
-                                    .font(.body)
-                                    .foregroundStyle(.primary)
-                                Text(option.registrationName ?? option.provider.displayName)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
+                List {
+                    ForEach(groupedFilteredOptions) { group in
+                        Section {
+                            ForEach(group.options, id: \.id) { option in
+                                optionRow(option)
                             }
-                            Spacer()
-                            if isSelected(option) {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .foregroundStyle(AppDesignSystem.Colors.success)
-                            }
+                        } header: {
+                            Text(group.key.title)
+                                .font(.caption)
                         }
                     }
-                    .buttonStyle(.plain)
                 }
             }
             .toolbar {
@@ -80,6 +86,68 @@ public struct EnhancementsModelSelectionSheet: View {
                 || option.provider.displayName.localizedCaseInsensitiveContains(query)
                 || option.registrationName?.localizedCaseInsensitiveContains(query) == true
         }
+    }
+
+    private var groupedFilteredOptions: [ProviderGroup] {
+        let sortedOptions = filteredOptions.sorted { lhs, rhs in
+            let lhsName = lhs.registrationName ?? lhs.provider.displayName
+            let rhsName = rhs.registrationName ?? rhs.provider.displayName
+
+            if lhsName.caseInsensitiveCompare(rhsName) == .orderedSame {
+                return lhs.modelID.localizedCaseInsensitiveCompare(rhs.modelID) == .orderedAscending
+            }
+
+            return lhsName.localizedCaseInsensitiveCompare(rhsName) == .orderedAscending
+        }
+
+        var groupsByKey: [ProviderGroup.Key: [EnhancementsProviderModelOption]] = [:]
+        var orderedKeys: [ProviderGroup.Key] = []
+
+        for option in sortedOptions {
+            let key = ProviderGroup.Key(
+                provider: option.provider,
+                registrationID: option.registrationID,
+                title: option.registrationName ?? option.provider.displayName
+            )
+
+            if groupsByKey[key] == nil {
+                orderedKeys.append(key)
+                groupsByKey[key] = []
+            }
+
+            groupsByKey[key, default: []].append(option)
+        }
+
+        return orderedKeys.compactMap { key in
+            guard let groupedOptions = groupsByKey[key], !groupedOptions.isEmpty else {
+                return nil
+            }
+
+            return ProviderGroup(
+                key: key,
+                options: groupedOptions
+            )
+        }
+    }
+
+    private func optionRow(_ option: EnhancementsProviderModelOption) -> some View {
+        Button {
+            onSelect(option)
+        } label: {
+            HStack(spacing: 8) {
+                Text(option.modelID)
+                    .font(.body)
+                    .foregroundStyle(.primary)
+
+                Spacer()
+
+                if isSelected(option) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(AppDesignSystem.Colors.success)
+                }
+            }
+        }
+        .buttonStyle(.plain)
     }
 
     private var searchField: some View {

--- a/Packages/MeetingAssistantCore/Sources/UI/components/settings/EnhancementsProviderAvatar.swift
+++ b/Packages/MeetingAssistantCore/Sources/UI/components/settings/EnhancementsProviderAvatar.swift
@@ -56,13 +56,17 @@ public struct EnhancementsProviderAvatar: View {
 
     private var resolvedSymbolName: String {
         guard provider == .custom,
-              let customIconName,
-              !customIconName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+              let customIconName
         else {
             return provider.icon
         }
 
-        return customIconName
+        let trimmedCustomIconName = customIconName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedCustomIconName.isEmpty else {
+            return provider.icon
+        }
+
+        return trimmedCustomIconName
     }
 
     private var logoImage: Image? {

--- a/Packages/MeetingAssistantCore/Sources/UI/components/settings/EnhancementsProviderAvatar.swift
+++ b/Packages/MeetingAssistantCore/Sources/UI/components/settings/EnhancementsProviderAvatar.swift
@@ -1,0 +1,88 @@
+import AppKit
+import MeetingAssistantCoreCommon
+import MeetingAssistantCoreInfrastructure
+import SwiftUI
+
+public struct EnhancementsProviderAvatar: View {
+    let provider: AIProvider
+    let customIconName: String?
+    let size: CGFloat
+    let glyphSize: CGFloat
+
+    public init(
+        provider: AIProvider,
+        customIconName: String? = nil,
+        size: CGFloat = 40,
+        glyphSize: CGFloat = 22
+    ) {
+        self.provider = provider
+        self.customIconName = customIconName
+        self.size = size
+        self.glyphSize = glyphSize
+    }
+
+    public var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: AppDesignSystem.Layout.smallCornerRadius)
+                .fill(provider.logoBackgroundColor)
+                .frame(width: size, height: size)
+                .overlay(
+                    RoundedRectangle(cornerRadius: AppDesignSystem.Layout.smallCornerRadius)
+                        .strokeBorder(AppDesignSystem.Colors.separator.opacity(0.18), lineWidth: 1)
+                )
+
+            if let logoImage {
+                if let tint = provider.logoTintColor {
+                    logoImage
+                        .renderingMode(.template)
+                        .resizable()
+                        .scaledToFit()
+                        .foregroundStyle(tint)
+                        .frame(width: glyphSize, height: glyphSize)
+                } else {
+                    logoImage
+                        .renderingMode(.original)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: glyphSize, height: glyphSize)
+                }
+            } else {
+                Image(systemName: resolvedSymbolName)
+                    .font(.system(size: min(CGFloat(16), glyphSize), weight: .semibold))
+                    .foregroundStyle(AppDesignSystem.Colors.accent)
+            }
+        }
+    }
+
+    private var resolvedSymbolName: String {
+        guard provider == .custom,
+              let customIconName,
+              !customIconName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return provider.icon
+        }
+
+        return customIconName
+    }
+
+    private var logoImage: Image? {
+        guard let logoAssetName = provider.logoAssetName else {
+            return nil
+        }
+
+        let logoURL = Bundle.module.url(forResource: logoAssetName, withExtension: "png")
+            ?? Bundle.module.url(
+                forResource: logoAssetName,
+                withExtension: "png",
+                subdirectory: "ProviderLogos"
+            )
+
+        guard let logoURL,
+              let nsImage = NSImage(contentsOf: logoURL)
+        else {
+            return nil
+        }
+
+        return Image(nsImage: nsImage)
+    }
+}

--- a/Packages/MeetingAssistantCore/Sources/UI/components/settings/EnhancementsProviderModelsPage.swift
+++ b/Packages/MeetingAssistantCore/Sources/UI/components/settings/EnhancementsProviderModelsPage.swift
@@ -39,6 +39,7 @@ public struct EnhancementsProviderModelsPage: View {
 
     @State var draftDisplayName = ""
     @State var draftBaseURL = ""
+    @State var draftIconSystemName: String?
     @State var draftAPIKey = ""
     @State var draftHasSavedAPIKey = false
     @State var draftConnectionStatus: ConnectionStatus = .unknown
@@ -115,6 +116,7 @@ public struct EnhancementsProviderModelsPage: View {
                 provider: context.provider,
                 displayName: $draftDisplayName,
                 baseURL: $draftBaseURL,
+                iconSystemName: $draftIconSystemName,
                 apiKey: $draftAPIKey,
                 hasSavedAPIKey: draftHasSavedAPIKey,
                 connectionStatus: draftConnectionStatus,
@@ -199,7 +201,10 @@ extension EnhancementsProviderModelsPage {
             beginEditRegistration(registration)
         } label: {
             HStack(alignment: .top, spacing: 12) {
-                EnhancementsProviderAvatar(provider: registration.provider)
+                EnhancementsProviderAvatar(
+                    provider: registration.provider,
+                    customIconName: registration.iconSystemName
+                )
 
                 VStack(alignment: .leading, spacing: 6) {
                     HStack(spacing: 8) {

--- a/Packages/MeetingAssistantCore/Sources/UI/components/settings/EnhancementsProviderModelsPage.swift
+++ b/Packages/MeetingAssistantCore/Sources/UI/components/settings/EnhancementsProviderModelsPage.swift
@@ -1,4 +1,3 @@
-import AppKit
 import MeetingAssistantCoreAI
 import MeetingAssistantCoreAudio
 import MeetingAssistantCoreCommon
@@ -200,7 +199,7 @@ extension EnhancementsProviderModelsPage {
             beginEditRegistration(registration)
         } label: {
             HStack(alignment: .top, spacing: 12) {
-                providerAvatar(for: registration.provider)
+                EnhancementsProviderAvatar(provider: registration.provider)
 
                 VStack(alignment: .leading, spacing: 6) {
                     HStack(spacing: 8) {
@@ -371,59 +370,6 @@ extension EnhancementsProviderModelsPage {
         }
     }
 
-    func providerAvatar(for provider: AIProvider) -> some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: AppDesignSystem.Layout.smallCornerRadius)
-                .fill(provider.logoBackgroundColor)
-                .frame(width: 40, height: 40)
-                .overlay(
-                    RoundedRectangle(cornerRadius: AppDesignSystem.Layout.smallCornerRadius)
-                        .strokeBorder(AppDesignSystem.Colors.separator.opacity(0.18), lineWidth: 1)
-                )
-
-            if let logoImage = providerLogoImage(for: provider) {
-                if let tint = provider.logoTintColor {
-                    logoImage
-                        .renderingMode(.template)
-                        .resizable()
-                        .scaledToFit()
-                        .foregroundStyle(tint)
-                        .frame(width: 22, height: 22)
-                } else {
-                    logoImage
-                        .renderingMode(.original)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 22, height: 22)
-                }
-            } else {
-                Image(systemName: provider.icon)
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundStyle(AppDesignSystem.Colors.accent)
-            }
-        }
-    }
-
-    func providerLogoImage(for provider: AIProvider) -> Image? {
-        guard let logoAssetName = provider.logoAssetName else {
-            return nil
-        }
-
-        let logoURL = Bundle.module.url(forResource: logoAssetName, withExtension: "png")
-            ?? Bundle.module.url(
-                forResource: logoAssetName,
-                withExtension: "png",
-                subdirectory: "ProviderLogos"
-            )
-
-        guard let logoURL,
-              let nsImage = NSImage(contentsOf: logoURL)
-        else {
-            return nil
-        }
-
-        return Image(nsImage: nsImage)
-    }
 }
 
 extension EnhancementsProviderModelsPage {

--- a/Packages/MeetingAssistantCore/Sources/UI/components/settings/EnhancementsProviderModelsPageEditing.swift
+++ b/Packages/MeetingAssistantCore/Sources/UI/components/settings/EnhancementsProviderModelsPageEditing.swift
@@ -16,7 +16,7 @@ extension EnhancementsProviderModelsPage {
         draftBaseURL = provider == .custom
             ? postProcessingViewModel.settings.aiConfiguration.baseURL
             : provider.defaultBaseURL
-        draftIconSystemName = provider == .custom ? provider.icon : nil
+        draftIconSystemName = nil
         draftAPIKey = ""
         draftHasSavedAPIKey = viewModel.hasSavedEnhancementsAPIKey(for: nil, provider: provider)
         draftConnectionStatus = draftHasSavedAPIKey ? .success : .unknown
@@ -258,11 +258,12 @@ extension EnhancementsProviderModelsPage {
 
         let resolvedIconSystemName: String? = if provider == .custom {
             if let normalizedIconSystemName,
-               EnhancementsProviderEditorSheet.curatedCustomProviderIcons.contains(normalizedIconSystemName)
+               EnhancementsProviderEditorSheet.curatedCustomProviderIcons.contains(normalizedIconSystemName),
+               normalizedIconSystemName != provider.icon
             {
                 normalizedIconSystemName
             } else {
-                provider.icon
+                nil
             }
         } else {
             nil

--- a/Packages/MeetingAssistantCore/Sources/UI/components/settings/EnhancementsProviderModelsPageEditing.swift
+++ b/Packages/MeetingAssistantCore/Sources/UI/components/settings/EnhancementsProviderModelsPageEditing.swift
@@ -5,6 +5,7 @@ import SwiftUI
 private struct ValidatedEditorDraft {
     let displayName: String
     let baseURL: String?
+    let iconSystemName: String?
 }
 
 extension EnhancementsProviderModelsPage {
@@ -15,6 +16,7 @@ extension EnhancementsProviderModelsPage {
         draftBaseURL = provider == .custom
             ? postProcessingViewModel.settings.aiConfiguration.baseURL
             : provider.defaultBaseURL
+        draftIconSystemName = provider == .custom ? provider.icon : nil
         draftAPIKey = ""
         draftHasSavedAPIKey = viewModel.hasSavedEnhancementsAPIKey(for: nil, provider: provider)
         draftConnectionStatus = draftHasSavedAPIKey ? .success : .unknown
@@ -30,6 +32,7 @@ extension EnhancementsProviderModelsPage {
     func beginEditRegistration(_ registration: EnhancementsProviderRegistration) {
         draftDisplayName = registration.displayName
         draftBaseURL = registration.provider == .custom ? registration.resolvedBaseURL : registration.provider.defaultBaseURL
+        draftIconSystemName = registration.iconSystemName ?? registration.provider.icon
         draftAPIKey = ""
         draftHasSavedAPIKey = viewModel.hasSavedEnhancementsAPIKey(
             for: registration.id,
@@ -133,7 +136,8 @@ extension EnhancementsProviderModelsPage {
             guard let created = settings.addEnhancementsProviderRegistration(
                 provider: context.provider,
                 displayName: draft.displayName,
-                baseURLOverride: draft.baseURL
+                baseURLOverride: draft.baseURL,
+                iconSystemName: draft.iconSystemName
             ) else {
                 draftErrorMessage = "settings.enhancements.providers.editor.create_failed".localized
                 return nil
@@ -151,6 +155,7 @@ extension EnhancementsProviderModelsPage {
             existing.displayName = draft.displayName
             if existing.provider == .custom {
                 existing.baseURLOverride = draft.baseURL
+                existing.iconSystemName = draft.iconSystemName
             }
             settings.updateEnhancementsProviderRegistration(existing)
             return existing
@@ -212,6 +217,7 @@ extension EnhancementsProviderModelsPage {
         let normalizedDisplayName = draftDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalizedBaseURL = draftBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalizedAPIKey = draftAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedIconSystemName = draftIconSystemName?.trimmingCharacters(in: .whitespacesAndNewlines)
 
         if provider == .custom {
             guard !normalizedDisplayName.isEmpty else {
@@ -250,9 +256,22 @@ extension EnhancementsProviderModelsPage {
             nil
         }
 
+        let resolvedIconSystemName: String? = if provider == .custom {
+            if let normalizedIconSystemName,
+               EnhancementsProviderEditorSheet.curatedCustomProviderIcons.contains(normalizedIconSystemName)
+            {
+                normalizedIconSystemName
+            } else {
+                provider.icon
+            }
+        } else {
+            nil
+        }
+
         return ValidatedEditorDraft(
             displayName: resolvedDisplayName,
-            baseURL: resolvedBaseURL
+            baseURL: resolvedBaseURL,
+            iconSystemName: resolvedIconSystemName
         )
     }
 }

--- a/Packages/MeetingAssistantCore/Sources/UI/components/settings/EnhancementsProviderPickerSheet.swift
+++ b/Packages/MeetingAssistantCore/Sources/UI/components/settings/EnhancementsProviderPickerSheet.swift
@@ -24,10 +24,11 @@ public struct EnhancementsProviderPickerSheet: View {
                     onSelect(provider)
                 } label: {
                     HStack(alignment: .top, spacing: 12) {
-                        Image(systemName: provider.icon)
-                            .font(.headline)
-                            .foregroundStyle(.secondary)
-                            .frame(width: 24)
+                        EnhancementsProviderAvatar(
+                            provider: provider,
+                            size: 24,
+                            glyphSize: 14
+                        )
 
                         VStack(alignment: .leading, spacing: 4) {
                             Text(provider.displayName)

--- a/Packages/MeetingAssistantCore/Sources/UI/components/settings/EnhancementsProviderRegistrationEditorSheet.swift
+++ b/Packages/MeetingAssistantCore/Sources/UI/components/settings/EnhancementsProviderRegistrationEditorSheet.swift
@@ -9,10 +9,34 @@ public enum EnhancementsProviderEditorMode {
 }
 
 public struct EnhancementsProviderEditorSheet: View {
+    static let curatedCustomProviderIcons: [String] = [
+        "server.rack",
+        "network",
+        "cloud",
+        "terminal",
+        "cpu",
+        "bolt.horizontal",
+        "link",
+        "shield",
+        "lock",
+        "key",
+        "antenna.radiowaves.left.and.right",
+        "globe",
+        "gearshape",
+        "shippingbox",
+        "puzzlepiece",
+        "wrench.and.screwdriver",
+        "sparkles",
+        "brain",
+        "text.bubble",
+        "wave.3.right",
+    ]
+
     let mode: EnhancementsProviderEditorMode
     let provider: AIProvider
     @Binding var displayName: String
     @Binding var baseURL: String
+    @Binding var iconSystemName: String?
     @Binding var apiKey: String
     let hasSavedAPIKey: Bool
     let connectionStatus: ConnectionStatus
@@ -28,6 +52,7 @@ public struct EnhancementsProviderEditorSheet: View {
         provider: AIProvider,
         displayName: Binding<String>,
         baseURL: Binding<String>,
+        iconSystemName: Binding<String?>,
         apiKey: Binding<String>,
         hasSavedAPIKey: Bool,
         connectionStatus: ConnectionStatus,
@@ -42,6 +67,7 @@ public struct EnhancementsProviderEditorSheet: View {
         self.provider = provider
         _displayName = displayName
         _baseURL = baseURL
+        _iconSystemName = iconSystemName
         _apiKey = apiKey
         self.hasSavedAPIKey = hasSavedAPIKey
         self.connectionStatus = connectionStatus
@@ -77,6 +103,8 @@ public struct EnhancementsProviderEditorSheet: View {
                     TextField("https://api.example.com/v1", text: $baseURL)
                         .textFieldStyle(.roundedBorder)
                 }
+
+                customIconSelector
             }
 
             VStack(alignment: .leading, spacing: 8) {
@@ -175,9 +203,12 @@ public struct EnhancementsProviderEditorSheet: View {
 
     private var providerHeader: some View {
         HStack(spacing: 10) {
-            Image(systemName: provider.icon)
-                .font(.headline)
-                .foregroundStyle(.secondary)
+            EnhancementsProviderAvatar(
+                provider: provider,
+                customIconName: provider == .custom ? resolvedCustomIconSystemName : nil,
+                size: 30,
+                glyphSize: 16
+            )
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(provider.displayName)
@@ -189,5 +220,65 @@ public struct EnhancementsProviderEditorSheet: View {
 
             Spacer()
         }
+    }
+
+    private var customIconSelector: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("settings.enhancements.providers.editor.icon".localized)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Text("settings.enhancements.providers.editor.icon_help".localized)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+
+            LazyVGrid(
+                columns: Array(repeating: GridItem(.flexible(minimum: 24), spacing: 8), count: 5),
+                alignment: .leading,
+                spacing: 8
+            ) {
+                ForEach(Self.curatedCustomProviderIcons, id: \.self) { symbolName in
+                    iconOptionButton(symbolName)
+                }
+            }
+        }
+    }
+
+    private func iconOptionButton(_ symbolName: String) -> some View {
+        let isSelected = resolvedCustomIconSystemName == symbolName
+
+        return Button {
+            iconSystemName = symbolName
+        } label: {
+            Image(systemName: symbolName)
+                .font(.system(size: 14, weight: .semibold))
+                .frame(width: 32, height: 32)
+                .foregroundStyle(isSelected ? AppDesignSystem.Colors.accent : .secondary)
+                .background(
+                    RoundedRectangle(cornerRadius: AppDesignSystem.Layout.smallCornerRadius)
+                        .fill(isSelected ? AppDesignSystem.Colors.accent.opacity(0.14) : AppDesignSystem.Colors.subtleFill)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: AppDesignSystem.Layout.smallCornerRadius)
+                        .strokeBorder(
+                            isSelected ? AppDesignSystem.Colors.accent : AppDesignSystem.Colors.separator.opacity(0.5),
+                            lineWidth: 1
+                        )
+                )
+        }
+        .buttonStyle(.plain)
+        .help(symbolName)
+        .accessibilityLabel(symbolName)
+    }
+
+    private var resolvedCustomIconSystemName: String {
+        let normalizedIconSystemName = iconSystemName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let normalizedIconSystemName,
+              Self.curatedCustomProviderIcons.contains(normalizedIconSystemName)
+        else {
+            return provider.icon
+        }
+
+        return normalizedIconSystemName
     }
 }

--- a/Packages/MeetingAssistantCore/Tests/MeetingAssistantCoreTests/AppSettingsStoreAISelectionTests.swift
+++ b/Packages/MeetingAssistantCore/Tests/MeetingAssistantCoreTests/AppSettingsStoreAISelectionTests.swift
@@ -353,6 +353,30 @@ final class AppSettingsStoreAISelectionTests: XCTestCase {
         XCTAssertNotEqual(firstCustom?.id, secondCustom?.id)
     }
 
+    func testAddEnhancementsProviderRegistration_PersistsCustomIconForCustomProvider() {
+        let registration = settings.addEnhancementsProviderRegistration(
+            provider: .custom,
+            displayName: "Gateway A",
+            baseURLOverride: "https://gateway-a.example/v1",
+            iconSystemName: "terminal"
+        )
+
+        XCTAssertEqual(registration?.iconSystemName, "terminal")
+        XCTAssertEqual(settings.enhancementsRegistrations(for: .custom).first?.iconSystemName, "terminal")
+    }
+
+    func testUpdateEnhancementsProviderRegistration_ClearsCustomIconForBuiltInProvider() {
+        let registration = settings.addEnhancementsProviderRegistration(provider: .openai)
+        var updated = registration
+        updated?.iconSystemName = "terminal"
+
+        if let updated {
+            settings.updateEnhancementsProviderRegistration(updated)
+        }
+
+        XCTAssertNil(settings.enhancementsRegistrations(for: .openai).first?.iconSystemName)
+    }
+
     func testRemoveEnhancementsProviderRegistration_ClearsSelectedEntryModel() throws {
         let custom = settings.addEnhancementsProviderRegistration(
             provider: .custom,


### PR DESCRIPTION
This pull request adds support for custom icons for AI provider registrations and improves the UI for selecting and displaying providers and their models. It introduces a new `EnhancementsProviderAvatar` view to consistently render provider avatars, updates the data model to store custom icon names, and enhances the provider model selection sheet with grouped and sorted options. Several UI and localization changes support these improvements.

**Custom Provider Icon Support**
* Added an optional `iconSystemName` property to `EnhancementsProviderRegistration` to allow custom icons for providers, including normalization and trimming logic. [[1]](diffhunk://#diff-5978205ba94e335882bef34b40885694e01c39fa46a4a4a7030a62b0cad793c5R237) [[2]](diffhunk://#diff-5978205ba94e335882bef34b40885694e01c39fa46a4a4a7030a62b0cad793c5R246-R254) [[3]](diffhunk://#diff-5978205ba94e335882bef34b40885694e01c39fa46a4a4a7030a62b0cad793c5R287-R292)
* Updated `AppSettingsStore.addEnhancementsProviderRegistration` to accept and store a custom `iconSystemName` for custom providers.

**UI Enhancements**
* Introduced the reusable `EnhancementsProviderAvatar` SwiftUI view for displaying provider avatars, supporting both built-in and custom icons.
* Updated `EnhancementsProviderModelsPage` to use the new avatar view and pass custom icon names, removing redundant avatar rendering code. [[1]](diffhunk://#diff-40745f2458429985e1cf1563e8baf0128b8208662aef6f74f7cb022e0be4cd11L203-R207) [[2]](diffhunk://#diff-40745f2458429985e1cf1563e8baf0128b8208662aef6f74f7cb022e0be4cd11L374-L426)
* Updated provider editing and creation flows to handle the new icon field in both the UI state and validation logic. [[1]](diffhunk://#diff-40745f2458429985e1cf1563e8baf0128b8208662aef6f74f7cb022e0be4cd11R42) [[2]](diffhunk://#diff-40745f2458429985e1cf1563e8baf0128b8208662aef6f74f7cb022e0be4cd11R119) [[3]](diffhunk://#diff-2df22a85ae31a161122357c9ec3ad8a3ec763873cc1eeb5c635117176e41bbf3R8) [[4]](diffhunk://#diff-2df22a85ae31a161122357c9ec3ad8a3ec763873cc1eeb5c635117176e41bbf3R19) [[5]](diffhunk://#diff-2df22a85ae31a161122357c9ec3ad8a3ec763873cc1eeb5c635117176e41bbf3R35)

**Provider Model Selection UI**
* Refactored `EnhancementsModelSelectionSheet` to group model options by provider/registration, sort them, and render with section headers for improved clarity. [[1]](diffhunk://#diff-7f7a3aec062e30c8db338e50c7407be20cee486280c3edf45448d6febd9cce42R6-R21) [[2]](diffhunk://#diff-7f7a3aec062e30c8db338e50c7407be20cee486280c3edf45448d6febd9cce42L41-L63) [[3]](diffhunk://#diff-7f7a3aec062e30c8db338e50c7407be20cee486280c3edf45448d6febd9cce42R91-R152)

**Localization**
* Added new localization keys for the provider icon field in both English and Portuguese. [[1]](diffhunk://#diff-c6553f104777411a4b5cb2b6ed3499b9c21ab4c58251fb9b2a799b6c3b360adaR290-R291) [[2]](diffhunk://#diff-031f8b40cf3b945cada39e5cddbf41dd3d7aa1868b2f80ff43ea5e496255f4dfR290-R291)

**Version Bump**
* Incremented the app version and build number in all relevant files for release tracking. [[1]](diffhunk://#diff-e22f3d16c14e3cea667f4eccdfe9a56ec324b9da12a5d92eb32af89920007567L25-R27) [[2]](diffhunk://#diff-bfb8a7b71375a816dc088aa10da4307258054d1523421544e6e65dca05cbae81L14-R16) [[3]](diffhunk://#diff-d7683b5bf1a04a3b89c1f36108e5408f191d3d8643be4ec111337b3b5e81686fL18-R21)

These changes collectively improve customization and clarity for users managing AI providers in the app.