### PR TITLE
fix(release): apply FluidAudio patches in CI parity

### DIFF
--- a/scripts/apply-fluidaudio-patches.sh
+++ b/scripts/apply-fluidaudio-patches.sh
@@ -9,21 +9,39 @@ PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
 patch_checkout() {
     local checkout_root="$1"
-    local asr_manager_path="${checkout_root}/Sources/FluidAudio/ASR/AsrManager.swift"
-    local streaming_asr_manager_path="${checkout_root}/Sources/FluidAudio/ASR/Streaming/StreamingAsrManager.swift"
+    local asr_manager_path
+    local streaming_asr_manager_path
+    local granite_models_path="${checkout_root}/Sources/FluidAudio/ASR/Granite/GraniteAsrModels.swift"
+    local granite_plus_models_path="${checkout_root}/Sources/FluidAudio/ASR/Granite/GranitePlusAsrModels.swift"
+    local nemotron_manager_path="${checkout_root}/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/NemotronStreamingAsrManager.swift"
+    local kokoro_memory_path="${checkout_root}/Sources/FluidAudio/TTS/Kokoro/Pipeline/Synthesize/KokoroSynthesizer+Memory.swift"
 
-    if [ ! -f "${asr_manager_path}" ]; then
+    if [ ! -d "${checkout_root}/Sources/FluidAudio" ]; then
         return 0
     fi
 
-    chmod u+w "${asr_manager_path}" 2>/dev/null || true
-    chmod u+w "${streaming_asr_manager_path}" 2>/dev/null || true
+    if [ -f "${checkout_root}/Sources/FluidAudio/ASR/AsrManager.swift" ]; then
+        asr_manager_path="${checkout_root}/Sources/FluidAudio/ASR/AsrManager.swift"
+    else
+        asr_manager_path="${checkout_root}/Sources/FluidAudio/ASR/Parakeet/AsrManager.swift"
+    fi
 
-    if ! grep -q "public final class AsrManager: @unchecked Sendable {" "${asr_manager_path}"; then
+    if [ -f "${checkout_root}/Sources/FluidAudio/ASR/Streaming/StreamingAsrManager.swift" ]; then
+        streaming_asr_manager_path="${checkout_root}/Sources/FluidAudio/ASR/Streaming/StreamingAsrManager.swift"
+    else
+        streaming_asr_manager_path="${checkout_root}/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift"
+    fi
+
+    chmod u+w "${asr_manager_path}" "${streaming_asr_manager_path}" "${granite_models_path}" \
+        "${granite_plus_models_path}" "${nemotron_manager_path}" "${kokoro_memory_path}" 2>/dev/null || true
+
+    if [ -f "${asr_manager_path}" ] && grep -q "public final class AsrManager" "${asr_manager_path}" \
+        && ! grep -q "public final class AsrManager: @unchecked Sendable {" "${asr_manager_path}"; then
         perl -0pi -e 's/public final class AsrManager(?::\s+Sendable)? \{/public final class AsrManager: \@unchecked Sendable {/g' "${asr_manager_path}"
     fi
 
-    if ! grep -q "public final class AsrManager: @unchecked Sendable {" "${asr_manager_path}"; then
+    if [ -f "${asr_manager_path}" ] && grep -q "public final class AsrManager" "${asr_manager_path}" \
+        && ! grep -q "public final class AsrManager: @unchecked Sendable {" "${asr_manager_path}"; then
         echo "Failed to patch FluidAudio checkout at ${checkout_root}" >&2
         exit 1
     fi
@@ -38,6 +56,38 @@ patch_checkout() {
             exit 1
         fi
     fi
+
+    if [ -f "${granite_models_path}" ]; then
+        perl -0pi -e 's/public struct GraniteAsrModels \{/public struct GraniteAsrModels: \@unchecked Sendable {/g' "${granite_models_path}"
+        if ! grep -q "public struct GraniteAsrModels: @unchecked Sendable {" "${granite_models_path}"; then
+            echo "Failed to patch GraniteAsrModels Sendable conformance at ${checkout_root}" >&2
+            exit 1
+        fi
+    fi
+
+    if [ -f "${granite_plus_models_path}" ]; then
+        perl -0pi -e 's/public struct GranitePlusAsrModels \{/public struct GranitePlusAsrModels: \@unchecked Sendable {/g' "${granite_plus_models_path}"
+        if ! grep -q "public struct GranitePlusAsrModels: @unchecked Sendable {" "${granite_plus_models_path}"; then
+            echo "Failed to patch GranitePlusAsrModels Sendable conformance at ${checkout_root}" >&2
+            exit 1
+        fi
+    fi
+
+    if [ -f "${nemotron_manager_path}" ]; then
+        perl -0pi -e 's/\n\s*case \.int8:\n\s*bytesPerElement = MemoryLayout<Int8>\.stride//g' "${nemotron_manager_path}"
+        if grep -q "case \\.int8:" "${nemotron_manager_path}"; then
+            echo "Failed to patch NemotronStreamingAsrManager int8 case at ${checkout_root}" >&2
+            exit 1
+        fi
+    fi
+
+    if [ -f "${kokoro_memory_path}" ]; then
+        perl -0pi -e 's/\s*#if canImport\(FoundationModels\).*?#endif/\n            @unknown default:\n                memset(array.dataPointer, 0, elementCount * MemoryLayout<Float>.stride)/sg' "${kokoro_memory_path}"
+        if grep -q "case \\.int8:" "${kokoro_memory_path}"; then
+            echo "Failed to patch KokoroSynthesizer memory int8 case at ${checkout_root}" >&2
+            exit 1
+        fi
+    fi
 }
 
 checkout_roots=("$@")
@@ -47,6 +97,7 @@ if [ "${#checkout_roots[@]}" -eq 0 ]; then
         "${PROJECT_DIR}/.xcode-build/SourcePackages/checkouts/FluidAudio"
         "${PROJECT_DIR}/.xcode-build-tests/SourcePackages/checkouts/FluidAudio"
         "${PROJECT_DIR}/.xcode-build-ci-parity/SourcePackages/checkouts/FluidAudio"
+        "${PROJECT_DIR}/.xcode-build-release-parity/SourcePackages/checkouts/FluidAudio"
         "${PROJECT_DIR}/build/DerivedData/SourcePackages/checkouts/FluidAudio"
     )
 

--- a/scripts/ci-release-parity.sh
+++ b/scripts/ci-release-parity.sh
@@ -156,6 +156,18 @@ resolve_spm_dependencies() {
     2>&1 | tee "${resolve_log}"
 }
 
+apply_dependency_patches() {
+  local fluidaudio_checkout="${DERIVED_DATA}/SourcePackages/checkouts/FluidAudio"
+
+  if [ ! -d "${fluidaudio_checkout}" ]; then
+    log_info "FluidAudio checkout not found at ${fluidaudio_checkout}; skipping dependency patches"
+    return 0
+  fi
+
+  log_info "Applying FluidAudio compatibility patches"
+  "${SCRIPT_DIR}/apply-fluidaudio-patches.sh" "${fluidaudio_checkout}"
+}
+
 locate_and_copy_sparkle_tools() {
   local sparkle_tool
   local sparkle_bin_dir
@@ -186,6 +198,7 @@ run_build_archive_phase() {
 
   xcode_version_check
   resolve_spm_dependencies "${PROJECT_ROOT}/build/ci-release-resolve-packages.log"
+  apply_dependency_patches
   locate_and_copy_sparkle_tools
 
   log_info "Running release build gate"


### PR DESCRIPTION
## Summary
- Apply existing FluidAudio compatibility patching during CI release parity after SPM dependency resolution.
- Update the patch script for the current FluidAudio checkout layout and Xcode 16.4 release-build failures.

## Evidence
- Risk: High (release/CI path)
- Reuse decision: Extend existing `scripts/apply-fluidaudio-patches.sh` and `scripts/ci-release-parity.sh`
- `bash -n scripts/apply-fluidaudio-patches.sh scripts/ci-release-parity.sh` passed
- `scripts/apply-fluidaudio-patches.sh /tmp/FluidAudio-release-debug` passed
- `scripts/ci-release-parity.sh --mode local --phase build-archive --dry-run 1` passed
- `make lint` exited 0; reported unrelated existing Swift format/lint issues outside touched files
- `make build-test` build passed; tests failed on existing environment/baseline failures unrelated to touched release scripts
