### PR TITLE
chore(release): bump version to 0.6.22

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -22,9 +22,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.21</string>
+	<string>0.6.22</string>
 	<key>CFBundleVersion</key>
-	<string>74</string>
+	<string>75</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MeetingAssistantAI/Resources/Info.plist
+++ b/MeetingAssistantAI/Resources/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.21</string>
+	<string>0.6.22</string>
 	<key>CFBundleVersion</key>
-	<string>74</string>
+	<string>75</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>MachServices</key>

--- a/Packages/MeetingAssistantCore/Sources/Common/AppVersion.swift
+++ b/Packages/MeetingAssistantCore/Sources/Common/AppVersion.swift
@@ -15,10 +15,10 @@ public enum AppVersion {
     // MARK: - Hardcoded Constants (Update these when releasing)
 
     /// Hardcoded version string - update this when releasing a new version
-    private static let hardcodedVersion = "0.6.21"
+    private static let hardcodedVersion = "0.6.22"
 
     /// Hardcoded build number - update this when creating a new build
-    private static let hardcodedBuild = "74"
+    private static let hardcodedBuild = "75"
 
     // MARK: - Public API
 


### PR DESCRIPTION
## Summary
- Bump app and XPC helper versions to 0.6.22 (build 75).
- Keep `AppVersion` fallback constants synchronized with release metadata.

## Evidence
- Risk: High (release path)
- Reuse decision: Reused `scripts/bump-version.sh`
- `bash -n scripts/bump-version.sh scripts/ci-release-parity.sh scripts/apply-fluidaudio-patches.sh` passed
