### PR TITLE
fix(audio): satisfy release compiler self captures

### DIFF
--- a/Packages/MeetingAssistantCore/Sources/Audio/Services/AudioRecorder/AudioRecorder.swift
+++ b/Packages/MeetingAssistantCore/Sources/Audio/Services/AudioRecorder/AudioRecorder.swift
@@ -196,10 +196,10 @@ public class AudioRecorder: ObservableObject, AudioRecordingService {
                     error: error
                 )
                 self.error = error
-                onRecordingError?(error)
+                self.onRecordingError?(error)
 
-                if isRecording {
-                    _ = await stopRecording()
+                if self.isRecording {
+                    _ = await self.stopRecording()
                 }
             }
         }
@@ -308,9 +308,9 @@ public class AudioRecorder: ObservableObject, AudioRecordingService {
         // Periodic metering for UI power updates
         simpleMeterTimer = Timer.scheduledTimer(withTimeInterval: Constants.simpleMeterUpdateInterval, repeats: true) { [weak self] _ in
             Task { @MainActor [weak self] in
-                guard let self, let rec = simpleRecorder else { return }
+                guard let self, let rec = self.simpleRecorder else { return }
                 rec.updateMeters()
-                publishMeterSnapshot(
+                self.publishMeterSnapshot(
                     averagePower: rec.averagePower(forChannel: 0),
                     peakPower: rec.peakPower(forChannel: 0),
                     barPowerLevels: []

--- a/Packages/MeetingAssistantCore/Sources/Audio/Services/AudioRecorder/Diagnostics.swift
+++ b/Packages/MeetingAssistantCore/Sources/Audio/Services/AudioRecorder/Diagnostics.swift
@@ -92,7 +92,7 @@ extension AudioRecorder {
         micDiagnosticsTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
             Task { @MainActor [weak self] in
                 guard let self else { return }
-                let peakBits = micDiagnosticsPeakBits.exchange(0, ordering: .relaxed)
+                let peakBits = self.micDiagnosticsPeakBits.exchange(0, ordering: .relaxed)
                 let peak = Float(bitPattern: peakBits)
                 let db = 20.0 * log10(max(peak, 1e-6))
 
@@ -102,7 +102,7 @@ extension AudioRecorder {
                 ]
 
                 // Include device identity for diagnosing wrong-device scenarios
-                if let inputUnit = audioEngine?.inputNode.audioUnit {
+                if let inputUnit = self.audioEngine?.inputNode.audioUnit {
                     var deviceID: AudioObjectID = 0
                     var size = UInt32(MemoryLayout<AudioObjectID>.size)
                     let status = AudioUnitGetProperty(
@@ -115,9 +115,9 @@ extension AudioRecorder {
                     )
                     if status == noErr {
                         extra["deviceID"] = deviceID
-                        extra["deviceName"] = deviceManager.getDeviceName(for: deviceID) ?? "Unknown"
-                        if let vol = deviceManager.getInputVolume(for: deviceID) { extra["volume"] = vol }
-                        if let muted = deviceManager.getInputMute(for: deviceID) { extra["muted"] = muted }
+                        extra["deviceName"] = self.deviceManager.getDeviceName(for: deviceID) ?? "Unknown"
+                        if let vol = self.deviceManager.getInputVolume(for: deviceID) { extra["volume"] = vol }
+                        if let muted = self.deviceManager.getInputMute(for: deviceID) { extra["muted"] = muted }
                     }
                 }
 


### PR DESCRIPTION
## Summary
- Add explicit `self.` references in audio recorder main-actor closures required by the Release Swift 6 compiler path.
- Preserve existing actor hops and behavior.

## Evidence
- Risk: High (audio + release compile path)
- Reuse decision: Extend existing closures; no new abstraction
- GitHub dry-run `28191913855` failed in `MeetingAssistantCoreAudio` with explicit-self diagnostics
- `scripts/ci-release-parity.sh --mode local --phase build-archive --dry-run 1` passed locally; only warning was local Xcode 26.5 vs CI Xcode 16.4
