### PR TITLE
fix(ui): support release build on Xcode 16

### DIFF
--- a/Packages/MeetingAssistantCore/Sources/UI/Presentation/FloatingRecordingIndicatorController.swift
+++ b/Packages/MeetingAssistantCore/Sources/UI/Presentation/FloatingRecordingIndicatorController.swift
@@ -209,7 +209,7 @@ public final class FloatingRecordingIndicatorController: ObservableObject {
             } completionHandler: { [weak self, weak panelToHide] in
                 Task { @MainActor [weak self, weak panelToHide] in
                     guard let self, let panelToHide else { return }
-                    guard visibilityTransitionID == transitionID else { return }
+                    guard self.visibilityTransitionID == transitionID else { return }
                     panelToHide.orderOut(nil)
                     panelToHide.alphaValue = 1
                 }

--- a/Packages/MeetingAssistantCore/Sources/UI/Services/RecordingManager/RecordingManagerIncrementalDictation.swift
+++ b/Packages/MeetingAssistantCore/Sources/UI/Services/RecordingManager/RecordingManagerIncrementalDictation.swift
@@ -50,7 +50,7 @@ extension RecordingManager {
                 onProcessedDurationChanged: { [weak self] (processedDuration: Double) in
                     Task { @MainActor [weak self] in
                         guard let self else { return }
-                        transcriptionStatus.updateProgress(
+                        self.transcriptionStatus.updateProgress(
                             phase: .processing,
                             processedSeconds: processedDuration
                         )

--- a/Packages/MeetingAssistantCore/Sources/UI/components/settings/MeetingNotesMarkdownEditor.swift
+++ b/Packages/MeetingAssistantCore/Sources/UI/components/settings/MeetingNotesMarkdownEditor.swift
@@ -343,6 +343,10 @@ private struct MeetingNotesMarkdownKeyboardHandler: NSViewRepresentable {
         nsView.onItalic = onItalic
         nsView.onLink = onLink
     }
+
+    static func dismantleNSView(_ nsView: KeyboardHandlerHostView, coordinator: ()) {
+        nsView.detach()
+    }
 }
 
 private final class KeyboardHandlerHostView: NSView {
@@ -356,6 +360,13 @@ private final class KeyboardHandlerHostView: NSView {
         removeMonitor()
         guard window != nil else { return }
         installMonitor()
+    }
+
+    func detach() {
+        removeMonitor()
+        onBold = nil
+        onItalic = nil
+        onLink = nil
     }
 
     private func installMonitor() {
@@ -391,10 +402,6 @@ private final class KeyboardHandlerHostView: NSView {
         default:
             return event
         }
-    }
-
-    @MainActor deinit {
-        removeMonitor()
     }
 }
 

--- a/Packages/MeetingAssistantCore/Sources/UI/components/settings/MeetingNotesRichTextEditor.swift
+++ b/Packages/MeetingAssistantCore/Sources/UI/components/settings/MeetingNotesRichTextEditor.swift
@@ -231,6 +231,10 @@ private struct MeetingNotesRichTextRepresentable: NSViewRepresentable {
         }
     }
 
+    static func dismantleNSView(_ nsView: NSScrollView, coordinator: Coordinator) {
+        coordinator.disconnect()
+    }
+
     func makeCoordinator() -> Coordinator {
         Coordinator(content: $content, controller: controller)
     }
@@ -259,10 +263,13 @@ private struct MeetingNotesRichTextRepresentable: NSViewRepresentable {
             self.controller = controller
         }
 
-        @MainActor deinit {
+        func disconnect() {
             if let textStorageDidProcessEditingObserver {
                 NotificationCenter.default.removeObserver(textStorageDidProcessEditingObserver)
+                self.textStorageDidProcessEditingObserver = nil
             }
+            observedTextStorage = nil
+            controller.textView = nil
         }
 
         func connect(textView: NSTextView) {

--- a/Packages/MeetingAssistantCore/Sources/UI/components/settings/SubtleScrollbarsModifier.swift
+++ b/Packages/MeetingAssistantCore/Sources/UI/components/settings/SubtleScrollbarsModifier.swift
@@ -60,12 +60,16 @@ private struct SubtleScrollbarsConfigurator: NSViewRepresentable {
 public extension View {
     @ViewBuilder
     func settingsScrollEdgeEffect() -> some View {
+        #if compiler(>=6.2)
         if #available(macOS 26.0, *) {
             scrollEdgeEffectStyle(.soft, for: .vertical)
                 .scrollEdgeEffectHidden(false, for: .vertical)
         } else {
             self
         }
+        #else
+        self
+        #endif
     }
 
     func subtleScrollbars() -> some View {


### PR DESCRIPTION
## Summary
- Fix Xcode 16 release compile diagnostics in UI closures and AppKit cleanup paths.
- Guard the macOS 26 scroll-edge modifier behind a compiler check so Xcode 16 SDK builds skip it.

## Evidence
- Risk: High (release compile path + UI/AppKit cleanup)
- Reuse decision: Extended existing closures/representable cleanup; no new abstraction
- GitHub dry-run `28193214393` exposed these Xcode 16 diagnostics
- `scripts/ci-release-parity.sh --mode local --phase build-archive --dry-run 1` passed locally; warning only for local Xcode 26.5 vs CI Xcode 16.4
