### PR TITLE
chore(release): bump version to 0.6.24

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -22,9 +22,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.23</string>
+	<string>0.6.24</string>
 	<key>CFBundleVersion</key>
-	<string>76</string>
+	<string>77</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MeetingAssistantAI/Resources/Info.plist
+++ b/MeetingAssistantAI/Resources/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.23</string>
+	<string>0.6.24</string>
 	<key>CFBundleVersion</key>
-	<string>76</string>
+	<string>77</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>MachServices</key>

--- a/Packages/MeetingAssistantCore/Sources/Common/AppVersion.swift
+++ b/Packages/MeetingAssistantCore/Sources/Common/AppVersion.swift
@@ -15,10 +15,10 @@ public enum AppVersion {
     // MARK: - Hardcoded Constants (Update these when releasing)
 
     /// Hardcoded version string - update this when releasing a new version
-    private static let hardcodedVersion = "0.6.23"
+    private static let hardcodedVersion = "0.6.24"
 
     /// Hardcoded build number - update this when creating a new build
-    private static let hardcodedBuild = "76"
+    private static let hardcodedBuild = "77"
 
     // MARK: - Public API
 


### PR DESCRIPTION
## Summary
- Bump app and XPC helper versions to 0.6.24 (build 77).
- Keep `AppVersion` fallback constants synchronized with release metadata.

## Evidence
- Risk: High (release path)
- Reuse decision: Reused `scripts/bump-version.sh`
- Prior local release archive parity passed after Xcode 16 compatibility fixes
