### PR TITLE
fix: harden guidance validation and artifact cleanup

### DIFF
--- a/.agents/skills/intelligence-kernel/SKILL.md
+++ b/.agents/skills/intelligence-kernel/SKILL.md
@@ -13,7 +13,7 @@ Operational guidance for the reusable intelligence kernel, canonical summary con
 
 - Use this skill for intelligence-kernel contracts, mode routing, trust flags, and benchmark gates.
 - Use `../data-persistence/SKILL.md` when the main concern is storage or migration rather than kernel behavior.
-- Use `../delivery-workflow/SKILL.md` when the main concern is command selection and verification policy.
+- Use global `delivery-workflow` when the main concern is command selection and verification policy.
 
 ## When to Use
 
@@ -59,6 +59,12 @@ Gate behavior through feature flags and settings adapters:
 
 Rule: call sites should stay on shared kernel contracts and avoid mode-specific branching in UI surfaces.
 
+## Persistence and Fallback Invariants
+
+- Preserve model-selection persistence across create, reload, edit, and delete flows; changes must be covered by contract tests.
+- When conversation state is missing or partial, use a schema-safe deterministic fallback rather than inventing context or silently dropping the request.
+- Update kernel-facing contract tests whenever persistence fields cross AI, Data, Domain, or UI boundaries.
+
 ## Benchmark and Regression Gates
 
 Commands:
@@ -100,4 +106,4 @@ Artifacts:
 
 - Cross-module API boundary decisions -> `../architecture/SKILL.md`
 - Persistence and migration impact -> `../data-persistence/SKILL.md`
-- Validation gates and test strategy -> `../delivery-workflow/SKILL.md`
+- Validation gates and test strategy -> global `delivery-workflow`

--- a/plans/113-interactive-release-build-and-install-runner.md
+++ b/plans/113-interactive-release-build-and-install-runner.md
@@ -207,7 +207,7 @@ Add focused AppKit coverage for exact URL acceptance/rejection where the test
 target can host it. At minimum, the exact URL behavior must be covered without
 starting a real recording or touching user data.
 
-**Verify**: the focused test passes; `make build-agent` compiles the route; and a manual smoke test with an idle installed app confirms that `open vocezinha://internal/quit` exits the app through the existing cleanup path.
+**Verify**: the focused test passes; `make build-agent` compiles the route; and a manual smoke test with an idle installed app confirms that `open vozinha://internal/quit` exits the app through the existing cleanup path.
 
 ### Step 3: Reuse release signing and build paths
 

--- a/scripts/agent-artifacts.py
+++ b/scripts/agent-artifacts.py
@@ -21,6 +21,7 @@ ALLOWED_ROOTS = (
 )
 ACTIVE_WINDOW_SECONDS = 15 * 60
 ACTIVE_MARKERS = (".lock", "build.db.lock", "index.lock")
+AGE_BUCKETS = ("<1d", "1-7d", "7-30d", "30d+")
 
 
 def human_size(size: int) -> str:
@@ -30,6 +31,16 @@ def human_size(size: int) -> str:
             return f"{value:.1f}{unit}"
         value /= 1024
     return f"{size}B"
+
+
+def age_bucket(age_days: float | None) -> str:
+    if age_days is None or age_days < 1:
+        return "<1d"
+    if age_days < 7:
+        return "1-7d"
+    if age_days < 30:
+        return "7-30d"
+    return "30d+"
 
 
 def artifact_root(project_root: Path, name: str) -> Path:
@@ -114,9 +125,39 @@ def print_report(items: list[dict[str, object]], now: float) -> None:
             f"files={item['files']} age={age} active={str(item['active']).lower()} "
             f"path={item['path']}"
         )
+    present = sorted(
+        (item for item in items if item["status"] == "present"),
+        key=lambda item: (-int(item["size"]), str(item["name"])),
+    )
+    for rank, item in enumerate(present, start=1):
+        print(
+            "ARTIFACT_LARGEST "
+            f"rank={rank} name={item['name']} size_bytes={item['size']}"
+        )
+    for bucket in AGE_BUCKETS:
+        bucket_items = [item for item in present if age_bucket(item.get("age_days")) == bucket]
+        bucket_size = sum(int(item["size"]) for item in bucket_items)
+        print(
+            "ARTIFACT_AGE_BUCKET "
+            f"bucket={bucket} roots={len(bucket_items)} size_bytes={bucket_size}"
+        )
+
+
+def has_project_ownership_marker(project_root: Path) -> bool:
+    resolved = project_root.resolve()
+    if resolved in {Path("/"), Path.home().resolve()}:
+        return False
+    git_marker = resolved / ".git"
+    return git_marker.is_dir() or git_marker.is_file()
 
 
 def cleanup(project_root: Path, items: list[dict[str, object]], older_than_days: float, dry_run: bool, confirm: bool) -> int:
+    if not has_project_ownership_marker(project_root):
+        print(
+            f"ERROR: refusing cleanup without a repository ownership marker: {project_root}",
+            file=sys.stderr,
+        )
+        return 1
     candidates = [
         item
         for item in items

--- a/scripts/check-localization.py
+++ b/scripts/check-localization.py
@@ -71,12 +71,21 @@ def check(root: Path) -> int:
     missing_from_pt = sorted(en_keys - pt_keys)
     missing_from_locales = sorted(used_keys - en_keys)
 
+    resource_root = root / "Packages/MeetingAssistantCore/Sources/Common/Resources"
     if missing_from_en:
-        errors.append(f"Missing from en: {', '.join(missing_from_en)}")
+        errors.append(
+            f"Missing from en ({resource_root / 'en.lproj/Localizable.strings'}): {', '.join(missing_from_en)}"
+        )
     if missing_from_pt:
-        errors.append(f"Missing from pt: {', '.join(missing_from_pt)}")
+        errors.append(
+            f"Missing from pt ({resource_root / 'pt.lproj/Localizable.strings'}): {', '.join(missing_from_pt)}"
+        )
     if missing_from_locales:
-        errors.append(f"Literal keys missing from locales: {', '.join(missing_from_locales)}")
+        errors.append(
+            "Literal keys missing from locales "
+            f"(Swift sources under {root / 'App'} and {root / 'Packages/MeetingAssistantCore/Sources'}): "
+            f"{', '.join(missing_from_locales)}"
+        )
 
     if errors:
         print("LOCALIZATION_CHECK_STATUS=FAIL")

--- a/scripts/scope-check.sh
+++ b/scripts/scope-check.sh
@@ -33,6 +33,9 @@ DIFF_RANGE_LABEL="HEAD -> working tree"
 TMP_FILES=()
 TARGETED_TESTS_RESULT=()
 FULL_RISK_REASONS=()
+CHANGED_FILES_RESULT=()
+DECISION_CODE_RELEVANT=0
+DECISION_GUIDANCE_RELEVANT=0
 SELECTED_LANE="fast"
 DECISION_STRATEGY="scoped-validation"
 
@@ -562,6 +565,49 @@ PY
     while IFS= read -r test_identifier; do
         [ -n "${test_identifier}" ] && TARGETED_TESTS_RESULT+=("${test_identifier}")
     done < "${targeted_tests_file}"
+
+    if ! python3 - "${decision_file}" > "${changed_file_list}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    changed_files = json.load(handle).get("decision", {}).get("changedFiles", [])
+if not isinstance(changed_files, list) or not changed_files or not all(isinstance(item, str) and item for item in changed_files):
+    raise SystemExit("invalid changed files")
+for item in sorted(set(changed_files)):
+    print(item)
+PY
+    then
+        echo "Error: decision file has invalid changed files: ${decision_file}"
+        return 1
+    fi
+    CHANGED_FILES_RESULT=()
+    while IFS= read -r file_path; do
+        [ -n "${file_path}" ] && CHANGED_FILES_RESULT+=("${file_path}")
+    done < "${changed_file_list}"
+
+    DECISION_CODE_RELEVANT="$(python3 - "${decision_file}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    value = json.load(handle).get("decision", {}).get("codeRelevant")
+if not isinstance(value, bool):
+    raise SystemExit("invalid code relevance")
+print(int(value))
+PY
+    )"
+    DECISION_GUIDANCE_RELEVANT="$(python3 - "${decision_file}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    value = json.load(handle).get("decision", {}).get("guidanceRelevant")
+if not isinstance(value, bool):
+    raise SystemExit("invalid guidance relevance")
+print(int(value))
+PY
+    )"
     return 0
 }
 
@@ -597,7 +643,8 @@ main() {
 
     if [ -n "${DECISION_FILE}" ]; then
         load_decision_file "${DECISION_FILE}" || return 1
-        code_relevant=1
+        code_relevant="${DECISION_CODE_RELEVANT}"
+        guidance_relevant="${DECISION_GUIDANCE_RELEVANT}"
         targeted_count=0
         : > "${full_reasons_file}"
         : > "${targeted_tests_file}"
@@ -626,6 +673,11 @@ main() {
         echo "No changed files detected. Nothing to validate."
         return 0
     fi
+
+    CHANGED_FILES_RESULT=()
+    while IFS= read -r file_path; do
+        [ -n "${file_path}" ] && CHANGED_FILES_RESULT+=("${file_path}")
+    done < "${changed_file_list}"
 
     while IFS= read -r file_path; do
         [ -n "${file_path}" ] || continue
@@ -683,18 +735,20 @@ main() {
         append_line_once "High product source-file churn detected (${product_source_files_changed} files > 8)" "${full_reasons_file}"
     fi
 
-    if [ "${guidance_relevant}" -eq 1 ]; then
-        echo "- Running guidance gate..."
-        run_cmd "make guidance-check" || return $?
-        echo "  Guidance passed."
-    fi
-
     if [ "${FORCE_FULL}" -eq 1 ]; then
         append_line_once "Forced full gate by flag (--force-full)" "${full_reasons_file}"
     fi
 
     if [ -s "${full_reasons_file}" ]; then
         should_run_full=1
+    fi
+
+    if [ -z "${DECISION_FILE}" ] && [ "${guidance_relevant}" -eq 1 ]; then
+        echo "- Running guidance gate..."
+        run_cmd "make guidance-check" || return $?
+        echo "  Guidance passed."
+        DECISION_CODE_RELEVANT="${code_relevant}"
+        DECISION_GUIDANCE_RELEVANT="${guidance_relevant}"
     fi
 
     if [ "${code_relevant}" -eq 0 ] && [ "${should_run_full}" -eq 0 ]; then
@@ -732,6 +786,14 @@ main() {
         SELECTED_LANE="fast"
         DECISION_STRATEGY="scoped-validation"
     fi
+    fi
+
+    if [ -n "${DECISION_FILE}" ] && [ "${guidance_relevant}" -eq 1 ]; then
+        echo "- Running guidance gate..."
+        run_cmd "make guidance-check" || return $?
+        echo "  Guidance passed."
+        DECISION_CODE_RELEVANT="${code_relevant}"
+        DECISION_GUIDANCE_RELEVANT="${guidance_relevant}"
     fi
 
     echo "Scoped validation plan:"
@@ -855,8 +917,12 @@ emit_agent_result() {
     if [ "${#FULL_RISK_REASONS[@]}" -gt 0 ]; then
         reasons_json="$(ma_agent_json_array "${FULL_RISK_REASONS[@]}")"
     fi
+    changed_files_json="[]"
+    if [ "${#CHANGED_FILES_RESULT[@]}" -gt 0 ]; then
+        changed_files_json="$(ma_agent_json_array "${CHANGED_FILES_RESULT[@]}")"
+    fi
     commands_json="[{\"name\":\"scope-check\",\"status\":\"${status}\",\"durationSec\":${duration},\"log\":\"$(ma_agent_json_escape "${LOG_PATH}")\"}]"
-    decision_json="{\"strategy\":\"${DECISION_STRATEGY}\",\"selectedLane\":\"${SELECTED_LANE}\",\"fullRisk\":$([ "${SELECTED_LANE}" = "full" ] && echo true || echo false),\"reasons\":${reasons_json},\"targetedTests\":${targeted_tests_json},\"diffRange\":\"$(ma_agent_json_escape "${DIFF_RANGE_LABEL}")\"}"
+    decision_json="{\"strategy\":\"${DECISION_STRATEGY}\",\"selectedLane\":\"${SELECTED_LANE}\",\"fullRisk\":$([ "${SELECTED_LANE}" = "full" ] && echo true || echo false),\"codeRelevant\":$([ "${code_relevant:-0}" -eq 1 ] && echo true || echo false),\"guidanceRelevant\":$([ "${guidance_relevant:-0}" -eq 1 ] && echo true || echo false),\"changedFiles\":${changed_files_json},\"reasons\":${reasons_json},\"targetedTests\":${targeted_tests_json},\"diffRange\":\"$(ma_agent_json_escape "${DIFF_RANGE_LABEL}")\"}"
     ma_agent_write_result_json "${RESULT_PATH}" "scope-check" "${status}" "${duration}" "${LOG_PATH}" "${error_count}" "${summary}" "${commands_json}" "${decision_json}"
     ma_agent_emit_result "scope-check" "${status}" "${duration}" "${LOG_PATH}" "${error_count}" "${summary}" "${RESULT_PATH}"
 }

--- a/scripts/tests/agent-artifacts-test.sh
+++ b/scripts/tests/agent-artifacts-test.sh
@@ -16,7 +16,7 @@ TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/prisma-agent-artifacts-test.XXXXXX")"
 trap 'rm -rf "${TMP_ROOT}"' EXIT
 
 fixture="${TMP_ROOT}/repo"
-mkdir -p "${fixture}/.xcode-build" "${fixture}/.xcode-build-tests" "${fixture}/not-managed"
+mkdir -p "${fixture}/.git" "${fixture}/.xcode-build" "${fixture}/.xcode-build-tests" "${fixture}/not-managed"
 printf '%s\n' old > "${fixture}/.xcode-build/old.bin"
 printf '%s\n' recent > "${fixture}/.xcode-build-tests/recent.bin"
 printf '%s\n' ignored > "${fixture}/not-managed/file.bin"
@@ -26,6 +26,8 @@ touch -t 202001010000 "${fixture}/.xcode-build"
 output="$(python3 "${SCRIPT_ROOT}/scripts/agent-artifacts.py" --root "${fixture}")"
 printf '%s\n' "${output}" | grep -Fq "AGENT_ARTIFACTS_STATUS=PASS"
 printf '%s\n' "${output}" | grep -Fq "name=.xcode-build"
+printf '%s\n' "${output}" | grep -Fq "ARTIFACT_LARGEST rank=1 name=.xcode-build"
+printf '%s\n' "${output}" | grep -Fq "ARTIFACT_AGE_BUCKET bucket=30d+"
 
 output="$(python3 "${SCRIPT_ROOT}/scripts/agent-artifacts.py" --root "${fixture}" --clean --dry-run --older-than-days 7)"
 printf '%s\n' "${output}" | grep -F "CLEANUP_TARGET" | grep -Fq ".xcode-build size_bytes="
@@ -43,5 +45,14 @@ python3 "${SCRIPT_ROOT}/scripts/agent-artifacts.py" --root "${fixture}" --clean 
 test ! -e "${fixture}/.xcode-build"
 test -d "${fixture}/.xcode-build-tests"
 test -e "${fixture}/not-managed/file.bin"
+
+unowned="${TMP_ROOT}/unowned"
+mkdir -p "${unowned}/.xcode-build"
+set +e
+python3 "${SCRIPT_ROOT}/scripts/agent-artifacts.py" --root "${unowned}" --clean --dry-run >/dev/null 2>&1
+status=$?
+set -e
+test "${status}" -eq 1
+test -d "${unowned}/.xcode-build"
 
 echo "AGENT_ARTIFACTS_TEST_STATUS=PASS"

--- a/scripts/tests/scope-classification-test.sh
+++ b/scripts/tests/scope-classification-test.sh
@@ -34,11 +34,12 @@ test_scope_check_reuses_decision_file() {
 
     fixture="$(new_fixture)"
     decision_file="${TMP_ROOT}/reused-decision.json"
-    printf '%s\n' '{"decision":{"selectedLane":"fast","strategy":"scoped-validation","reasons":[],"targetedTests":[],"diffRange":"fixture decision"}}' > "${decision_file}"
+    printf '%s\n' '{"decision":{"selectedLane":"fast","strategy":"scoped-validation","codeRelevant":false,"guidanceRelevant":true,"changedFiles":["AGENTS.md"],"reasons":[],"targetedTests":[],"diffRange":"fixture decision"}}' > "${decision_file}"
     output="$(cd "${fixture}" && MA_AGENT_LOG_DIR="${TMP_ROOT}/reused-decision" ./scripts/scope-check.sh --agent --decision-file "${decision_file}" --no-build)"
     assert_contains "${output}" "AGENT_STATUS=PASS"
     assert_contains "${output}" "Added lines (fixture decision): 0"
     assert_not_contains "${output}" "No changed files detected"
+    assert_contains "${output}" "Guidance passed."
 }
 
 test_app_product_swift_is_full() {


### PR DESCRIPTION
## Summary
- require a repository ownership marker before cleanup
- preserve changed files and guidance/code relevance when reusing scope decisions
- add deterministic artifact ranking/age buckets and localization file diagnostics
- restore the exact `vozinha://internal/quit` plan contract

## Validation
- `bash -n scripts/scope-check.sh`
- `./scripts/tests/agent-artifacts-test.sh`
- `./scripts/tests/localization-check-test.sh`
- `make workflow-test`
- `git diff --check`