### PR TITLE
feat(build): add transactional release runner

### DIFF
--- a/.agents/docs/build-and-test.md
+++ b/.agents/docs/build-and-test.md
@@ -63,6 +63,8 @@ make preflight-fast     # Lint + Build + Test (skips benchmark, faster feedback)
 make ci-release-parity  # Sparkle release build/archive parity gate (local)
 make deliverable-gate   # build-test + lint + ci-release-parity
 make run                # Run app in debug mode
+make build-and-run      # Interactive Debug/Release workflow
+make install-release    # Non-interactive Release install and launch
 make format             # Auto-format with SwiftFormat
 make lint               # Run SwiftLint checks
 ```
@@ -74,6 +76,13 @@ make dmg                # Create DMG installer (auto-detect self-signed identity
 make setup-self-signed-cert # Bootstrap local self-signed code-signing cert
 make ci-release-parity-self-signed DOWNLOAD_URL_PREFIX=... RELEASE_TAG=... # Signed Sparkle parity (archive + appcast)
 ```
+
+`make build-and-run` never installs Debug into `/Applications`. Release
+consumes the signed `dist/Vozinha.app`, validates it, and transactionally
+replaces only `/Applications/Vozinha.app`, restoring the previous bundle on
+failure. `--force-terminate` is an explicit fallback after the graceful
+`vozinha://internal/quit` request times out. `make dmg` remains the packaging
+flow.
 
 DMG signing mode selection:
 

--- a/App/AppDelegate/AppDelegateLifecycle.swift
+++ b/App/AppDelegate/AppDelegateLifecycle.swift
@@ -50,6 +50,13 @@ extension AppDelegate {
         scheduleLaunchVisibilityRecovery()
     }
 
+    func application(_ application: NSApplication, open urls: [URL]) {
+        guard urls.contains(where: { $0.scheme == "vozinha" && $0.host == "internal" && $0.path == "/quit" && $0.query == nil }) else {
+            return
+        }
+        quitApp()
+    }
+
     func applicationWillTerminate(_ notification: Notification) {
         localModelResidencyCoordinator.stopMonitoring()
         recordingCancelShortcutController.stop()

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -25,6 +25,13 @@
 	<string>0.7.23</string>
 	<key>CFBundleVersion</key>
 	<string>91</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array><string>vozinha</string></array>
+		</dict>
+	</array>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # with CI/CD pipelines and headless environments.
 # =============================================================================
 
-.PHONY: help build build-debug build-release build-agent build-test build-test-strict xcodebuild-safe test test-agent test-full test-full-agent test-smoke test-perf test-sensitive test-appkit test-parity test-parity-agent test-swift test-verbose test-strict test-ci-strict scope-check scope-check-agent validate-agent workflow-test benchmark-summary benchmark-summary-agent lint lint-agent lint-strict lint-strict-agent lint-fix arch-check preview-check localization-check guidance-check preflight preflight-fast preflight-agent preflight-agent-fast agent-artifacts-report agent-artifacts-dry-run agent-artifacts-clean clean run run-release dmg setup-self-signed-cert setup format health ci-build ci-test ci-release-parity ci-release-parity-self-signed deliverable-gate docs docs-preview docs-clean profile profile-report profile-cpu profile-memory profile-animation profile-animation-report
+.PHONY: help build build-debug build-release build-agent build-test build-test-strict xcodebuild-safe test test-agent test-full test-full-agent test-smoke test-perf test-sensitive test-appkit test-parity test-parity-agent test-swift test-verbose test-strict test-ci-strict scope-check scope-check-agent validate-agent workflow-test benchmark-summary benchmark-summary-agent lint lint-agent lint-strict lint-strict-agent lint-fix arch-check preview-check localization-check guidance-check preflight preflight-fast preflight-agent preflight-agent-fast agent-artifacts-report agent-artifacts-dry-run agent-artifacts-clean clean run run-release build-and-run install-release dmg setup-self-signed-cert setup format health ci-build ci-test ci-release-parity ci-release-parity-self-signed deliverable-gate docs docs-preview docs-clean profile profile-report profile-cpu profile-memory profile-animation profile-animation-report
 
 # Default target
 help:
@@ -62,6 +62,8 @@ help:
 	@echo "Run Commands:"
 	@echo "  make run            - Build and run debug version"
 	@echo "  make run-release    - Build and run release version"
+	@echo "  make build-and-run ARGS=... - Interactive Debug/Release build workflow"
+	@echo "  make install-release ARGS=... - Build, install, validate, and launch Release Vozinha.app"
 	@echo ""
 	@echo "Distribution:"
 	@echo "  make dmg            - Create DMG installer (prompts for auto/self-signed/adhoc at start)"
@@ -275,6 +277,12 @@ run: build-debug
 run-release: build-release
 	@echo -e "$(YELLOW)Launching $(APP_PRODUCT_NAME) (Release)...$(NC)"
 	@open "$(DERIVED_DATA)/Build/Products/Release/$(APP_PRODUCT_NAME).app"
+
+build-and-run:
+	@./scripts/build-and-run.sh $(ARGS)
+
+install-release:
+	@./scripts/build-and-run.sh --no-interactive --configuration Release $(ARGS)
 
 # Distribution
 new-release:

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ The pre-commit hook applies SwiftFormat and SwiftLint autofix to staged Swift fi
 |--------|-------------|
 | `make run` | Build Debug and open the app. |
 | `make run-release` | Build Release and open the app. |
+| `make build-and-run` | Interactively choose Debug or Release; Release installs transactionally into `/Applications/Vozinha.app`. |
+| `make install-release` | Non-interactively build, validate, install, and launch Release; use `ARGS=--skip-launch` for verification only. |
 | `make dmg` | Build Release and create `dist/Vozinha.dmg`, prompting for automatic, self-signed, or ad-hoc signing. |
 | `make setup-self-signed-cert` | Create or import the local self-signed signing certificate. |
 | `make new-release` | Create a GitHub release interactively with generated notes. |

--- a/plans/README.md
+++ b/plans/README.md
@@ -30,7 +30,7 @@ Status values: `TODO` | `IN PROGRESS` | `DONE` | `BLOCKED` | `REJECTED`.
 | [110](archive/completed/110-wire-vocabulary-through-transcription.md) | Wire vocabulary snapshots through transcription and enhancement | P1 | L | 109 | DONE |
 | [111](archive/completed/111-add-dictionary-quick-add-panel.md) | Add the VoiceInk-style Dictionary quick-add panel | P1 | L | 109 | DONE |
 | [112](112-rebrand-visible-app-name-to-vozinha.md) | Rebrand the visible app name to Vozinha | P1 | L | - | IN PROGRESS |
-| [113](113-interactive-release-build-and-install-runner.md) | Add an interactive Release-aware build and install runner | P1 | L | 112 | TODO |
+| [113](113-interactive-release-build-and-install-runner.md) | Add an interactive Release-aware build and install runner | P1 | L | 112 | IN PROGRESS |
 | [114](114-prune-dated-agent-guidance.md) | Prune dated agent guidance without losing durable rules | P0 | M | 105 | DONE |
 | [115](115-promote-localization-integrity-gate.md) | Promote localization integrity to a deterministic gate | P0 | M | 102 | DONE |
 | [116](116-reuse-scope-check-decision.md) | Reuse the scope-check decision in agent validation | P1 | S | 103 | DONE |

--- a/scripts/build-and-run.sh
+++ b/scripts/build-and-run.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# build-and-run.sh - Build Debug or install the signed Release app transactionally.
+set -euo pipefail
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${PROJECT_ROOT}/scripts/config/app_identity.sh"
+CONFIGURATION=""; CLEAN=0; NO_INTERACTIVE=0; FORCE_TERMINATE=0; SKIP_LAUNCH=0
+APPLICATIONS_DIR="${VOZINHA_APPLICATIONS_DIR:-/Applications}"
+SHUTDOWN_TIMEOUT="${VOZINHA_SHUTDOWN_TIMEOUT_SECONDS:-15}"; STARTUP_TIMEOUT="${VOZINHA_STARTUP_TIMEOUT_SECONDS:-15}"
+usage() { cat <<'USAGE'
+Usage: scripts/build-and-run.sh [options]
+
+Build Debug for local iteration or build/sign/install Release into the exact Vozinha.app target.
+Options:
+  --configuration Debug|Release  Select a deterministic build mode.
+  --clean                       Remove this repository's .xcode-build first.
+  --no-interactive              Never read stdin; requires --configuration.
+  --force-terminate             Allow exact-process TERM fallback after graceful timeout.
+  --skip-launch                 Verify Release installation without relaunching it.
+  --applications-dir PATH       Test-only applications root; defaults to /Applications.
+  --help                        Show this help without building.
+USAGE
+}
+fail() { echo "Error: $*" >&2; exit 1; }
+require_positive_integer() { [[ "$1" =~ ^[1-9][0-9]*$ ]] || fail "timeout must be a positive integer: $1"; }
+validate_applications_dir() {
+    local root="$1" resolved
+    [ -d "$root" ] || fail "applications directory does not exist: $root"
+    resolved="$(cd "$root" && pwd -P)"
+    [ "$resolved" != "/" ] || fail "refusing the filesystem root as an installation target"
+    [ "$resolved" != "${HOME:-}" ] || fail "refusing the home directory as an installation target"
+    printf '%s\n' "$resolved"
+}
+bundle_path() { printf '%s/%s.app\n' "$1" "$APP_PRODUCT_NAME"; }
+validate_bundle() {
+    local bundle="$1" identifier
+    [ -d "$bundle" ] || return 1
+    [ "$(basename "$bundle")" = "${APP_PRODUCT_NAME}.app" ] || return 1
+    [ -f "$bundle/Contents/Info.plist" ] || return 1
+    identifier="$(plutil -extract CFBundleIdentifier raw -o - "$bundle/Contents/Info.plist" 2>/dev/null || true)"
+    [ -n "$identifier" ] || return 1
+    [ -f "$bundle/Contents/MacOS/${APP_PRODUCT_NAME}" ] || return 1
+    codesign --verify --deep --strict "$bundle" >/dev/null 2>&1 || return 1
+}
+running_pids() { pgrep -x "$APP_PRODUCT_NAME" 2>/dev/null || true; }
+wait_for_exit() {
+    local deadline=$((SECONDS + SHUTDOWN_TIMEOUT))
+    while [ "$SECONDS" -lt "$deadline" ]; do [ -z "$(running_pids)" ] && return 0; sleep 1; done
+    return 1
+}
+stop_running_app() {
+    local pids; pids="$(running_pids)"; [ -z "$pids" ] && return 0
+    echo "Requesting graceful shutdown via vozinha://internal/quit..."
+    open "vozinha://internal/quit" >/dev/null 2>&1 || true
+    wait_for_exit && return 0
+    [ "$FORCE_TERMINATE" -eq 1 ] || fail "Vozinha did not terminate gracefully within ${SHUTDOWN_TIMEOUT}s; rerun with --force-terminate only if intended"
+    echo "Graceful shutdown timed out; using explicit TERM fallback for PID(s): ${pids}" >&2
+    while IFS= read -r pid; do [ -n "$pid" ] && kill -TERM "$pid" 2>/dev/null || true; done <<< "$pids"
+    wait_for_exit || fail "Vozinha remained running after explicit force fallback"
+}
+rollback() {
+    local target="$1" backup="$2"; rm -rf "$target"
+    if [ -d "$backup" ]; then mv "$backup" "$target"; echo "Rollback restored ${target}" >&2; else echo "Rollback had no previous bundle to restore" >&2; fi
+}
+install_release() {
+    local candidate="$PROJECT_ROOT/dist/${APP_PRODUCT_NAME}.app" target stage backup had_backup=0
+    target="$(bundle_path "$APPLICATIONS_DIR")"; stage="${target}.stage.$$"; backup="${target}.backup.$$"
+    validate_bundle "$candidate" || fail "Release candidate is not installable"
+    case "$target" in "${APPLICATIONS_DIR}/${APP_PRODUCT_NAME}.app") ;; *) fail "Refusing unexpected installation target: $target" ;; esac
+    stop_running_app; rm -rf "$stage"
+    ditto "$candidate" "$stage" || { rm -rf "$stage"; fail "Could not stage Release candidate"; }
+    if [ -e "$target" ]; then mv "$target" "$backup" || { rm -rf "$stage"; fail "Could not create installation backup"; }; had_backup=1; fi
+    if ! mv "$stage" "$target" || ! validate_bundle "$target"; then rm -rf "$stage"; [ "$had_backup" -eq 1 ] && mv "$backup" "$target"; fail "Release installation failed; rollback was attempted"; fi
+    if [ "$SKIP_LAUNCH" -eq 0 ]; then
+        open "$target" >/dev/null 2>&1 || { rollback "$target" "$backup"; fail "Release app failed to launch"; }
+        local deadline=$((SECONDS + STARTUP_TIMEOUT)); while [ "$SECONDS" -lt "$deadline" ] && [ -z "$(running_pids)" ]; do sleep 1; done
+        [ -n "$(running_pids)" ] || { rollback "$target" "$backup"; fail "Release app did not remain alive after launch"; }
+    fi
+    rm -rf "$backup"; echo "Installed and validated ${target}"
+}
+run_selected() {
+    [ "$CLEAN" -eq 1 ] && rm -rf "$PROJECT_ROOT/.xcode-build"
+    if [ "$CONFIGURATION" = "Debug" ]; then
+        "$PROJECT_ROOT/scripts/run-build.sh" --configuration Debug
+        open "$PROJECT_ROOT/.xcode-build/Build/Products/Debug/${APP_PRODUCT_NAME}.app"
+    else
+        MA_RELEASE_SIGNING_MODE="${MA_RELEASE_SIGNING_MODE:-adhoc}" "$PROJECT_ROOT/scripts/build-release.sh" --no-interactive
+        install_release
+    fi
+}
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --configuration) [ $# -ge 2 ] || fail "--configuration requires Debug or Release"; CONFIGURATION="$2"; shift 2 ;;
+        --clean) CLEAN=1; shift ;;
+        --no-interactive) NO_INTERACTIVE=1; shift ;;
+        --force-terminate) FORCE_TERMINATE=1; shift ;;
+        --skip-launch) SKIP_LAUNCH=1; shift ;;
+        --applications-dir) [ $# -ge 2 ] || fail "--applications-dir requires a path"; APPLICATIONS_DIR="$2"; shift 2 ;;
+        --help|-h) usage; exit 0 ;;
+        *) fail "unknown option: $1" ;;
+    esac
+done
+require_positive_integer "$SHUTDOWN_TIMEOUT"; require_positive_integer "$STARTUP_TIMEOUT"
+if [ "$NO_INTERACTIVE" -eq 1 ]; then
+    [ -n "$CONFIGURATION" ] || fail "--no-interactive requires --configuration Debug|Release"
+elif [ -z "$CONFIGURATION" ]; then
+    [ -t 0 ] && [ -t 1 ] || fail "interactive selection requires a TTY; pass --no-interactive --configuration ..."
+    printf '%s\n' '1) Debug' '2) Release' '3) Exit'; read -r -p "Choose [1/2/3]: " choice
+    case "$choice" in 1) CONFIGURATION=Debug ;; 2) CONFIGURATION=Release ;; *) exit 0 ;; esac
+fi
+case "$CONFIGURATION" in Debug) ;; Release) APPLICATIONS_DIR="$(validate_applications_dir "$APPLICATIONS_DIR")" ;; *) fail "configuration must be Debug or Release" ;; esac
+run_selected

--- a/scripts/tests/build-and-run-test.sh
+++ b/scripts/tests/build-and-run-test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+help_output="$(${SCRIPT_ROOT}/scripts/build-and-run.sh --help)"
+printf '%s\n' "$help_output" | grep -Fq -- '--no-interactive'
+printf '%s\n' "$help_output" | grep -Fq -- '--force-terminate'
+printf '%s\n' "$help_output" | grep -Fq -- 'Debug'
+printf '%s\n' "$help_output" | grep -Fq -- 'Release'
+
+set +e
+noninteractive_output="$(${SCRIPT_ROOT}/scripts/build-and-run.sh --no-interactive 2>&1)"
+noninteractive_status=$?
+set -e
+[ "$noninteractive_status" -ne 0 ]
+printf '%s\n' "$noninteractive_output" | grep -Fq -- 'requires --configuration'
+
+set +e
+invalid_output="$(${SCRIPT_ROOT}/scripts/build-and-run.sh --configuration Release --no-interactive --applications-dir / 2>&1)"
+invalid_status=$?
+set -e
+[ "$invalid_status" -ne 0 ]
+printf '%s\n' "$invalid_output" | grep -Fq -- 'filesystem root'
+
+echo "BUILD_AND_RUN_TEST_STATUS=PASS"


### PR DESCRIPTION
## Summary
- add interactive and deterministic `build-and-run` / `install-release` workflows
- add exact `vozinha://internal/quit` graceful shutdown route
- validate and transactionally replace only `Vozinha.app` with rollback
- document the Debug/Release boundaries and add fixture coverage

## Validation
- `./scripts/tests/build-and-run-test.sh`
- `make guidance-check`
- `make build-agent`
- `make validate-agent ARGS="--lane full --no-reuse --agent"`
- `make ci-release-parity` attempted; existing Sparkle XCFramework path failure documented in handoff.